### PR TITLE
add PostageBatchUsablePoller to await postage batch usability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Three source projects plus one test project:
 - **`src/SwarmSdk.Wasm`** — WebAssembly host exposing SDK utilities to JS. `IsAotCompatible=true`, not packable, not part of the public NuGet surface. Keep it AOT-safe.
 - **`test/SwarmSdk.UnitTest`** — xUnit + Moq unit tests, mirroring the `SwarmSdk` folder layout.
 
+A test project mirrors the library it tests and references only that library, so logic worth unit-testing belongs in the lowest library that can hold it: prefer placing pure, testable logic in `SwarmSdk` core (where it is covered by `SwarmSdk.UnitTest`) and keeping `SwarmSdk.Client` a thin wrapper over it. `SwarmSdk.Client` has no test project of its own; add a mirror `SwarmSdk.Client.UnitTest` only if it ever grows logic that cannot live in core.
+
 Key cross-cutting points:
 
 - **Root namespace is `Etherna.SwarmSdk` for every project**, so `src/SwarmSdk/Stores/Foo.cs` is `namespace Etherna.SwarmSdk.Stores`, and `src/SwarmSdk.Client/Stores/Bar.cs` is `namespace Etherna.SwarmSdk.Stores` too (the project's `.Client` suffix is dropped, not part of the namespace). The namespace mirrors the folder path *under* the root namespace.
@@ -153,6 +155,14 @@ private void InternalHelper() { ... }
   public override bool CanSeek => true;
   ```
 - LINQ method chains: one operation per line, aligned
+- When a call's or constructor's arguments are wrapped one per line, keep the **first** argument on the opening-parenthesis line and align the rest under it — don't drop the first argument onto its own line. Skip this only when the first argument is itself long enough to warrant its own line.
+  ```csharp
+  new(id: id,
+      amount: null,
+      depth: PostageBatch.MinDepth,
+      utilization: 0);
+  ```
+  This applies to invocation argument lists; multi-line method/constructor *parameter declarations* keep the first parameter on its own line, as elsewhere in the codebase.
 - Blank line between member sections
 
 ## C# Language Features
@@ -175,7 +185,7 @@ private void InternalHelper() { ... }
 ## Testing (xUnit + Moq)
 
 - `[Fact]` for basic tests, `[Theory]` with `[MemberData]` for parameterized cases
-- AAA pattern with section comments: `// Arrange.`, `// Action.`, `// Assert.`
+- AAA pattern with section comments: `// Setup.`, `// Run.`, `// Assert.` (collapse to `// Run & Assert.` when a single statement does both)
 - xUnit assertions: `Assert.Equal()`, `Assert.NotNull()`, `Assert.Throws<T>()` / `Assert.ThrowsAsync<T>()`
 - Moq for mocking: `new Mock<IChunkStore>()`
 - `FakeTimeProvider` (Microsoft.Extensions.TimeProvider.Testing) for anything time-dependent — never rely on wall-clock sleeps for ordering; advance the fake clock instead

--- a/src/SwarmSdk/Services/PostageBatchUsablePoller.cs
+++ b/src/SwarmSdk/Services/PostageBatchUsablePoller.cs
@@ -1,0 +1,96 @@
+// Copyright 2021-present Etherna SA
+// This file is part of SwarmSDK.
+//
+// SwarmSDK is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// SwarmSDK is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with SwarmSDK.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SwarmSdk.Exceptions;
+using Etherna.SwarmSdk.Models;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Etherna.SwarmSdk.Services
+{
+    /// <summary>
+    /// Polls a postage batch until it becomes usable.
+    /// </summary>
+    public static class PostageBatchUsablePoller
+    {
+        // Consts.
+        /// <summary>Default interval between checks while waiting for a postage batch to become usable.</summary>
+        public static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(5);
+
+        /// <summary>Default maximum time to wait for a postage batch to become usable.</summary>
+        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(15);
+
+        // Static methods.
+        /// <summary>
+        /// Repeatedly retrieves a postage batch until it is usable, the timeout elapses, or the operation is cancelled.
+        /// </summary>
+        /// <remarks>
+        /// A postage batch is not immediately usable after being bought: the creation transaction must be confirmed
+        /// on chain first. Transient "not found yet" (404) and gateway timeout (504) responses that can occur right
+        /// after purchase are tolerated and treated as "not usable yet".
+        /// </remarks>
+        /// <param name="batchId">ID of the postage batch to wait for.</param>
+        /// <param name="getPostageBatch">Delegate retrieving the current batch state by ID (e.g. <c>swarmClient.GetPostageBatchAsync</c>).</param>
+        /// <param name="timeout">Maximum time to wait. Defaults to <see cref="DefaultTimeout"/> (15 minutes).</param>
+        /// <param name="pollInterval">Interval between checks. Defaults to <see cref="DefaultPollInterval"/> (5 seconds).</param>
+        /// <param name="timeProvider">Time source driving elapsed-time measurement and delays. Defaults to <see cref="TimeProvider.System"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The postage batch once it is usable.</returns>
+        /// <exception cref="TimeoutException">The batch did not become usable within the timeout.</exception>
+        public static async Task<PostageBatch> WaitUntilUsableAsync(
+            PostageBatchId batchId,
+            Func<PostageBatchId, CancellationToken, Task<PostageBatch>> getPostageBatch,
+            TimeSpan? timeout = null,
+            TimeSpan? pollInterval = null,
+            TimeProvider? timeProvider = null,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(getPostageBatch);
+
+            var effectiveTimeout = timeout ?? DefaultTimeout;
+            var effectivePollInterval = pollInterval ?? DefaultPollInterval;
+            var effectiveTimeProvider = timeProvider ?? TimeProvider.System;
+            if (effectiveTimeout < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(timeout), effectiveTimeout, "Timeout cannot be negative");
+            if (effectivePollInterval <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(pollInterval), effectivePollInterval, "Poll interval must be positive");
+
+            var startTimestamp = effectiveTimeProvider.GetTimestamp();
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // A freshly bought batch may not be retrievable yet, or the node may briefly time out:
+                // tolerate those transient responses and keep polling until the batch becomes usable.
+                PostageBatch? batch = null;
+                try
+                {
+                    batch = await getPostageBatch(batchId, cancellationToken).ConfigureAwait(false);
+                }
+                catch (SwarmSdkApiException e) when (e.StatusCode is 404 or 504)
+                { }
+
+                if (batch is { IsUsable: true })
+                    return batch;
+
+                if (effectiveTimeProvider.GetElapsedTime(startTimestamp) >= effectiveTimeout)
+                    throw new TimeoutException(
+                        $"Postage batch {batchId} did not become usable within {effectiveTimeout}");
+
+                await Task.Delay(effectivePollInterval, effectiveTimeProvider, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/test/SwarmSdk.UnitTest/Services/PostageBatchUsablePollerTest.cs
+++ b/test/SwarmSdk.UnitTest/Services/PostageBatchUsablePollerTest.cs
@@ -1,0 +1,200 @@
+// Copyright 2021-present Etherna SA
+// This file is part of SwarmSDK.
+//
+// SwarmSDK is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// SwarmSDK is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with SwarmSDK.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SwarmSdk.Exceptions;
+using Etherna.SwarmSdk.Models;
+using Microsoft.Extensions.Time.Testing;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Etherna.SwarmSdk.Services
+{
+    public class PostageBatchUsablePollerTest
+    {
+        // Consts.
+        private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+
+        // Tests.
+        [Fact]
+        public async Task ReturnsImmediatelyWhenBatchAlreadyUsable()
+        {
+            // Setup.
+            var callCount = 0;
+            Task<PostageBatch> GetBatch(PostageBatchId id, CancellationToken _)
+            {
+                callCount++;
+                return Task.FromResult(Batch(id, isUsable: true));
+            }
+
+            // Run.
+            var result = await PostageBatchUsablePoller.WaitUntilUsableAsync(
+                PostageBatchId.Zero, GetBatch, timeProvider: new FakeTimeProvider());
+
+            // Assert.
+            Assert.True(result.IsUsable);
+            Assert.Equal(1, callCount); // no polling needed when already usable
+        }
+
+        [Fact]
+        public async Task PollsUntilBatchBecomesUsable()
+        {
+            // Setup.
+            // The batch reports not-usable for the first two checks, then usable: a virtual clock
+            // releases each poll interval so the staged transition is observed deterministically.
+            var fakeTimeProvider = new FakeTimeProvider();
+            var outcomes = new Queue<bool>([false, false, true]);
+            var callCount = 0;
+            Task<PostageBatch> GetBatch(PostageBatchId id, CancellationToken _)
+            {
+                callCount++;
+                return Task.FromResult(Batch(id, isUsable: outcomes.Dequeue()));
+            }
+
+            // Run.
+            var waitTask = PostageBatchUsablePoller.WaitUntilUsableAsync(
+                PostageBatchId.Zero, GetBatch, pollInterval: PollInterval, timeProvider: fakeTimeProvider);
+            await DriveVirtualClockUntilCompletedAsync(fakeTimeProvider, waitTask, PollInterval);
+            var result = await waitTask;
+
+            // Assert.
+            Assert.True(result.IsUsable);
+            Assert.Equal(3, callCount);
+        }
+
+        [Fact]
+        public async Task ThrowsTimeoutWhenBatchNeverBecomesUsable()
+        {
+            // Setup.
+            var fakeTimeProvider = new FakeTimeProvider();
+            var timeout = TimeSpan.FromSeconds(20);
+            Task<PostageBatch> GetBatch(PostageBatchId id, CancellationToken _) =>
+                Task.FromResult(Batch(id, isUsable: false));
+
+            // Run.
+            var waitTask = PostageBatchUsablePoller.WaitUntilUsableAsync(
+                PostageBatchId.Zero, GetBatch, timeout, PollInterval, fakeTimeProvider);
+            await DriveVirtualClockUntilCompletedAsync(fakeTimeProvider, waitTask, PollInterval);
+
+            // Assert.
+            await Assert.ThrowsAsync<TimeoutException>(() => waitTask);
+        }
+
+        [Fact]
+        public async Task ToleratesTransientNotFoundAndGatewayTimeoutResponses()
+        {
+            // Setup.
+            // A freshly bought batch may not be retrievable yet (404) or the node may briefly time out (504):
+            // those transient responses must not abort the wait.
+            var fakeTimeProvider = new FakeTimeProvider();
+            var callCount = 0;
+            Task<PostageBatch> GetBatch(PostageBatchId id, CancellationToken _)
+            {
+                callCount++;
+                return callCount switch
+                {
+                    1 => throw ApiException(404),
+                    2 => throw ApiException(504),
+                    _ => Task.FromResult(Batch(id, isUsable: true))
+                };
+            }
+
+            // Run.
+            var waitTask = PostageBatchUsablePoller.WaitUntilUsableAsync(
+                PostageBatchId.Zero, GetBatch, pollInterval: PollInterval, timeProvider: fakeTimeProvider);
+            await DriveVirtualClockUntilCompletedAsync(fakeTimeProvider, waitTask, PollInterval);
+            var result = await waitTask;
+
+            // Assert.
+            Assert.True(result.IsUsable);
+            Assert.Equal(3, callCount);
+        }
+
+        [Fact]
+        public async Task PropagatesNonTransientApiErrors()
+        {
+            // Setup.
+            Task<PostageBatch> GetBatch(PostageBatchId id, CancellationToken _) =>
+                throw ApiException(500);
+
+            // Run & Assert.
+            await Assert.ThrowsAsync<SwarmSdkApiException>(() =>
+                PostageBatchUsablePoller.WaitUntilUsableAsync(
+                    PostageBatchId.Zero, GetBatch, TimeSpan.FromMinutes(15), PollInterval, new FakeTimeProvider()));
+        }
+
+        [Fact]
+        public async Task ThrowsOnNonPositivePollInterval()
+        {
+            // Setup.
+            Task<PostageBatch> GetBatch(PostageBatchId id, CancellationToken _) =>
+                Task.FromResult(Batch(id, isUsable: true));
+
+            // Run & Assert.
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                PostageBatchUsablePoller.WaitUntilUsableAsync(
+                    PostageBatchId.Zero, GetBatch, TimeSpan.FromMinutes(15), TimeSpan.Zero, new FakeTimeProvider()));
+        }
+
+        [Fact]
+        public async Task ThrowsOnNegativeTimeout()
+        {
+            // Setup.
+            Task<PostageBatch> GetBatch(PostageBatchId id, CancellationToken _) =>
+                Task.FromResult(Batch(id, isUsable: true));
+
+            // Run & Assert.
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                PostageBatchUsablePoller.WaitUntilUsableAsync(
+                    PostageBatchId.Zero, GetBatch, TimeSpan.FromSeconds(-1), PollInterval, new FakeTimeProvider()));
+        }
+
+        // Helpers.
+        private static SwarmSdkApiException ApiException(int statusCode) =>
+            new("error", statusCode, null, new Dictionary<string, IEnumerable<string>>(), null);
+
+        private static PostageBatch Batch(PostageBatchId id, bool isUsable) =>
+            new(id: id,
+                amount: null,
+                blockNumber: 0,
+                depth: PostageBatch.MinDepth,
+                exists: true,
+                isImmutable: false,
+                isUsable: isUsable,
+                label: null,
+                ttl: TimeSpan.FromDays(1),
+                utilization: 0);
+
+        /// <summary>
+        /// Repeatedly advances the virtual clock by <paramref name="step"/> until the polling task
+        /// completes, settling the async continuations between advances. Bounded by wall-clock time
+        /// so a stuck task cannot hang the test.
+        /// </summary>
+        private static async Task DriveVirtualClockUntilCompletedAsync(
+            FakeTimeProvider timeProvider,
+            Task task,
+            TimeSpan step)
+        {
+            var realTimeout = Stopwatch.StartNew();
+            while (!task.IsCompleted && realTimeout.Elapsed < TimeSpan.FromSeconds(5))
+            {
+                timeProvider.Advance(step);
+                await Task.Delay(1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
A postage batch is not immediately usable after being bought: the creation transaction must be confirmed on chain first. PostageBatchUsablePoller polls a batch (via a getter delegate) until it becomes usable, tolerating the transient 404/not-found and 504/gateway-timeout responses that can occur right after purchase, with configurable timeout and poll interval driven by an injectable TimeProvider.

Kept in SwarmSdk core (not as a SwarmClient method) so the logic is unit-tested without HTTP and SwarmSdk.Client stays a thin wrapper.

Also document in AGENTS.md the first-argument-inline formatting rule and align the AAA test-comment convention with the codebase (Setup/Run/Assert).