### PR TITLE
add UploadRetrier with opt-in retry for chunk and bzz uploads

### DIFF
--- a/src/SwarmSdk.Client/ISwarmClient.cs
+++ b/src/SwarmSdk.Client/ISwarmClient.cs
@@ -79,10 +79,12 @@ namespace Etherna.SwarmSdk
         /// <summary>Upload a collection of chunks in a single bulk request.</summary>
         /// <param name="chunks">Chunks to upload.</param>
         /// <param name="batchId">ID of Postage Batch that is used to upload data with.</param>
+        /// <param name="maxUploadAttempts">Maximum number of attempts per chunk push (initial try plus retries). 1 disables retrying. Retrying is safe because re-sending already-stamped chunks is idempotent.</param>
         /// <exception cref="SwarmSdkApiException">A server side error occurred.</exception>
         Task ChunksBulkUploadAsync(
             SwarmChunk[] chunks,
             PostageBatchId batchId,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default);
 
         /// <summary>Connect to address.</summary>
@@ -855,7 +857,9 @@ namespace Etherna.SwarmSdk
         /// <param name="actHistoryAddress">ACT history reference address.</param>
         /// <param name="deferredUpload">Determines if the uploaded data should be sent to the network immediately or in a deferred fashion. By default the upload will be deferred.</param>
         /// <param name="redundancyLevel">Add redundancy to the data being uploaded so that downloaders can download it with better UX. 0 value is default and does not add any redundancy to the file.</param>
+        /// <param name="maxUploadAttempts">Maximum number of upload attempts (initial try plus retries) on transient failures. 1 disables retrying. Requires a seekable <paramref name="body"/> when greater than 1.</param>
         /// <returns>Content reference</returns>
+        /// <remarks>Retrying reuses the same postage batch. For plain uploads this is idempotent, since the content addresses are deterministic. When <paramref name="encrypt"/> is true the content is re-encrypted with a fresh random key on each attempt, so a retry produces a different reference and consumes additional batch utilization.</remarks>
         /// <exception cref="SwarmSdkApiException">A server side error occurred.</exception>
         Task<SwarmReference> UploadBytesAsync(
             Stream body,
@@ -868,6 +872,7 @@ namespace Etherna.SwarmSdk
             string? actHistoryAddress = null,
             bool? deferredUpload = null,
             RedundancyLevel redundancyLevel = RedundancyLevel.None,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default);
 
         /// <summary>Upload a chunk.</summary>
@@ -919,7 +924,9 @@ namespace Etherna.SwarmSdk
         /// <param name="redundancyLevel">Add redundancy to the data being uploaded so that downloaders can download it with better UX. 0 value is default and does not add any redundancy to the file.</param>
         /// <param name="act">Determines if the uploaded data should be treated as ACT (Access Control Trie) content.</param>
         /// <param name="actHistoryAddress">ACT history reference address.</param>
+        /// <param name="maxUploadAttempts">Maximum number of upload attempts (initial try plus retries) on transient failures. 1 disables retrying.</param>
         /// <returns>Content reference</returns>
+        /// <remarks>Retrying reuses the same postage batch. For plain uploads this is idempotent, since the content addresses are deterministic. When <paramref name="encrypt"/> is true the content is re-encrypted with a fresh random key on each attempt, so a retry produces a different reference and consumes additional batch utilization.</remarks>
         /// <exception cref="SwarmSdkApiException">A server side error occurred.</exception>
         Task<SwarmReference> UploadDirectoryAsync(
             string directoryPath,
@@ -934,6 +941,7 @@ namespace Etherna.SwarmSdk
             RedundancyLevel redundancyLevel = RedundancyLevel.None,
             bool? act = null,
             string? actHistoryAddress = null,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default);
 
         /// <summary>Upload feed root manifest.</summary>
@@ -968,7 +976,9 @@ namespace Etherna.SwarmSdk
         /// <param name="errorDocument">Custom error document to return when a path is not found in the collection.</param>
         /// <param name="deferredUpload">Determines if the uploaded data should be sent to the network immediately or in a deferred fashion. By default the upload will be deferred.</param>
         /// <param name="redundancyLevel">Add redundancy to the data being uploaded so that downloaders can download it with better UX. 0 value is default and does not add any redundancy to the file.</param>
+        /// <param name="maxUploadAttempts">Maximum number of upload attempts (initial try plus retries) on transient failures. 1 disables retrying. Requires a seekable <paramref name="content"/> when greater than 1.</param>
         /// <returns>Content reference</returns>
+        /// <remarks>Retrying reuses the same postage batch. For plain uploads this is idempotent, since the content addresses are deterministic. When <paramref name="encrypt"/> is true the content is re-encrypted with a fresh random key on each attempt, so a retry produces a different reference and consumes additional batch utilization.</remarks>
         /// <exception cref="SwarmSdkApiException">A server side error occurred.</exception>
         Task<SwarmReference> UploadFileAsync(
             Stream content,
@@ -984,6 +994,7 @@ namespace Etherna.SwarmSdk
             string? errorDocument = null,
             bool? deferredUpload = null,
             RedundancyLevel redundancyLevel = RedundancyLevel.None,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default);
 
         /// <summary>Upload single owner chunk.</summary>

--- a/src/SwarmSdk.Client/SwarmClient.cs
+++ b/src/SwarmSdk.Client/SwarmClient.cs
@@ -16,6 +16,7 @@ using Etherna.SwarmSdk.Clients.Bee;
 using Etherna.SwarmSdk.Exceptions;
 using Etherna.SwarmSdk.Extensions;
 using Etherna.SwarmSdk.Models;
+using Etherna.SwarmSdk.Services;
 using Etherna.SwarmSdk.Tools;
 using System;
 using System.Collections.Generic;
@@ -242,24 +243,32 @@ namespace Etherna.SwarmSdk
         public async Task ChunksBulkUploadAsync(
             SwarmChunk[] chunks,
             PostageBatchId batchId,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(chunks);
-            
+
             if (IsDryMode)
                 return;
-            
+
             switch (ApiCompatibility)
             {
                 case SwarmClients.Bee:
                 {
                     foreach (var chunk in chunks)
                     {
-                        using var memoryStream = new MemoryStream(chunk.GetFullPayloadToByteArray());
-                    
-                        await UploadChunkAsync(
-                            memoryStream,
-                            batchId,
+                        // Re-sending an already-stamped chunk is idempotent, so each push can be retried safely.
+                        var chunkPayload = chunk.GetFullPayloadToByteArray();
+                        await UploadRetrier.ExecuteWithRetryAsync(
+                            async ct =>
+                            {
+                                using var memoryStream = new MemoryStream(chunkPayload);
+                                await UploadChunkAsync(
+                                    memoryStream,
+                                    batchId,
+                                    cancellationToken: ct).ConfigureAwait(false);
+                            },
+                            maxAttempts: maxUploadAttempts,
                             cancellationToken: cancellationToken).ConfigureAwait(false);
                     }
                     break;
@@ -278,20 +287,26 @@ namespace Etherna.SwarmSdk
 
                         //chunk data
                         payload.AddRange(chunkBytes.Span);
-                
+
                         //check hash
                         payload.AddRange(chunk.Hash.ToByteArray());
                     }
-            
+
                     var byteArrayPayload = payload.ToArray();
-                    using var memoryStream = new MemoryStream(byteArrayPayload);
-                    
-                    // Upload stream.
-                    await beehiveGeneratedClient.Ev1ChunksBulkUploadAsync(
-                        swarm_Postage_Batch_Id: batchId.ToString(),
-                        new FileParameter(memoryStream),
+
+                    // Upload stream. The payload is rebuilt on each attempt because the stream is consumed by the send.
+                    await UploadRetrier.ExecuteWithRetryAsync(
+                        async ct =>
+                        {
+                            using var memoryStream = new MemoryStream(byteArrayPayload);
+                            await beehiveGeneratedClient.Ev1ChunksBulkUploadAsync(
+                                swarm_Postage_Batch_Id: batchId.ToString(),
+                                new FileParameter(memoryStream),
+                                cancellationToken: ct).ConfigureAwait(false);
+                        },
+                        maxAttempts: maxUploadAttempts,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
-                    
+
                     break;
                 }
                 default:
@@ -2722,37 +2737,55 @@ namespace Etherna.SwarmSdk
             string? actHistoryAddress = null,
             bool? deferredUpload = null,
             RedundancyLevel redundancyLevel = RedundancyLevel.None,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(body);
+
             if (IsDryMode)
                 return encrypt == true ? SwarmReference.EncryptedZero : SwarmReference.PlainZero;
 
-            switch (ApiCompatibility)
-            {
-                case SwarmClients.Bee:
-                    return (await beeGeneratedClient.BytesPostAsync(
-                        swarm_postage_batch_id: batchId.ToString(),
-                        swarm_tag: tagId?.Value,
-                        swarm_pin: pin,
-                        swarm_deferred_upload: deferredUpload,
-                        swarm_encrypt: encrypt,
-                        swarm_redundancy_level: (Clients.Bee.SwarmRedundancyLevel)redundancyLevel,
-                        swarm_act: act,
-                        swarm_act_history_address: actHistoryAddress,
-                        body: body,
-                        cancellationToken: cancellationToken).ConfigureAwait(false)).Reference;
-                case SwarmClients.Beehive:
-                    return (await beehiveGeneratedClient.BytesPostAsync(
-                        swarm_Postage_Batch_Id: batchId.ToString(),
-                        body: new FileParameter(body),
-                        swarm_Compact_Level: compactLevel,
-                        swarm_Encrypt: encrypt,
-                        swarm_Pin: pin,
-                        swarm_Redundancy_Level: (Clients.Beehive.RedundancyLevel?)redundancyLevel,
-                        cancellationToken: cancellationToken).ConfigureAwait(false)).Reference;
-                default:
-                    throw new InvalidOperationException();
-            }
+            // Retrying needs to resend the same data, so a non-seekable stream cannot be rewound.
+            if (maxUploadAttempts > 1 && !body.CanSeek)
+                throw new ArgumentException(
+                    "A seekable stream is required to retry the upload; set maxUploadAttempts to 1 for non-seekable streams.",
+                    nameof(body));
+            var startPosition = body.CanSeek ? body.Position : 0L;
+
+            return await UploadRetrier.ExecuteWithRetryAsync(
+                async ct =>
+                {
+                    if (body.CanSeek)
+                        body.Position = startPosition;
+                    switch (ApiCompatibility)
+                    {
+                        case SwarmClients.Bee:
+                            return (await beeGeneratedClient.BytesPostAsync(
+                                swarm_postage_batch_id: batchId.ToString(),
+                                swarm_tag: tagId?.Value,
+                                swarm_pin: pin,
+                                swarm_deferred_upload: deferredUpload,
+                                swarm_encrypt: encrypt,
+                                swarm_redundancy_level: (Clients.Bee.SwarmRedundancyLevel)redundancyLevel,
+                                swarm_act: act,
+                                swarm_act_history_address: actHistoryAddress,
+                                body: body,
+                                cancellationToken: ct).ConfigureAwait(false)).Reference;
+                        case SwarmClients.Beehive:
+                            return (await beehiveGeneratedClient.BytesPostAsync(
+                                swarm_Postage_Batch_Id: batchId.ToString(),
+                                body: new FileParameter(body),
+                                swarm_Compact_Level: compactLevel,
+                                swarm_Encrypt: encrypt,
+                                swarm_Pin: pin,
+                                swarm_Redundancy_Level: (Clients.Beehive.RedundancyLevel?)redundancyLevel,
+                                cancellationToken: ct).ConfigureAwait(false)).Reference;
+                        default:
+                            throw new InvalidOperationException();
+                    }
+                },
+                maxAttempts: maxUploadAttempts,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         public Task<SwarmHash> UploadChunkAsync(
@@ -2826,59 +2859,66 @@ namespace Etherna.SwarmSdk
             RedundancyLevel redundancyLevel = RedundancyLevel.None,
             bool? act = null,
             string? actHistoryAddress = null,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default)
         {
             if (IsDryMode)
                 return encrypt == true ? SwarmReference.EncryptedZero : SwarmReference.PlainZero;
 
-            // Create tar file.
+            // Create tar file once; the seekable stream is rewound before each attempt.
             using var memoryStream = new MemoryStream();
             await TarFile.CreateFromDirectoryAsync(directoryPath, memoryStream, false, cancellationToken).ConfigureAwait(false);
-            memoryStream.Position = 0;
-            
+
             // Try set index document.
             if (indexDocument is null &&
                 File.Exists(Path.Combine(directoryPath, "index.html")))
                 indexDocument = "index.html";
 
             // Upload directory.
-            switch (ApiCompatibility)
-            {
-                case SwarmClients.Bee:
-                    return (await beeGeneratedClient.BzzPostAsync(
-                        name: null,
-                        swarm_tag: tagId?.Value,
-                        swarm_pin: pin,
-                        swarm_encrypt: encrypt,
-                        content_Type: "application/x-tar",
-                        swarm_collection: true,
-                        swarm_index_document: indexDocument,
-                        swarm_error_document: errorDocument,
-                        swarm_postage_batch_id: batchId.ToString(),
-                        swarm_deferred_upload: deferredUpload,
-                        swarm_redundancy_level: (Clients.Bee.SwarmRedundancyLevel)redundancyLevel,
-                        swarm_act: act,
-                        swarm_act_history_address: actHistoryAddress,
-                        body: memoryStream,
-                        cancellationToken: cancellationToken).ConfigureAwait(false)).Reference;
-                case SwarmClients.Beehive:
-                    return (await beehiveGeneratedClient.BzzPostAsync(
-                        file: new Clients.Beehive.FileParameter(
-                            data: memoryStream,
-                            fileName: null,
-                            contentType: "application/x-tar"),
-                        swarm_Postage_Batch_Id: batchId.ToString(),
-                        swarm_Compact_Level: compactLevel,
-                        swarm_Encrypt: encrypt,
-                        swarm_Pin: pin,
-                        swarm_Redundancy_Level: (Clients.Beehive.RedundancyLevel)redundancyLevel,
-                        swarm_Collection: true,
-                        swarm_Index_Document: indexDocument,
-                        swarm_Error_Document: errorDocument,
-                        cancellationToken: cancellationToken).ConfigureAwait(false)).Reference;
-                default:
-                    throw new InvalidOperationException();
-            }
+            return await UploadRetrier.ExecuteWithRetryAsync(
+                async ct =>
+                {
+                    memoryStream.Position = 0;
+                    switch (ApiCompatibility)
+                    {
+                        case SwarmClients.Bee:
+                            return (await beeGeneratedClient.BzzPostAsync(
+                                name: null,
+                                swarm_tag: tagId?.Value,
+                                swarm_pin: pin,
+                                swarm_encrypt: encrypt,
+                                content_Type: "application/x-tar",
+                                swarm_collection: true,
+                                swarm_index_document: indexDocument,
+                                swarm_error_document: errorDocument,
+                                swarm_postage_batch_id: batchId.ToString(),
+                                swarm_deferred_upload: deferredUpload,
+                                swarm_redundancy_level: (Clients.Bee.SwarmRedundancyLevel)redundancyLevel,
+                                swarm_act: act,
+                                swarm_act_history_address: actHistoryAddress,
+                                body: memoryStream,
+                                cancellationToken: ct).ConfigureAwait(false)).Reference;
+                        case SwarmClients.Beehive:
+                            return (await beehiveGeneratedClient.BzzPostAsync(
+                                file: new Clients.Beehive.FileParameter(
+                                    data: memoryStream,
+                                    fileName: null,
+                                    contentType: "application/x-tar"),
+                                swarm_Postage_Batch_Id: batchId.ToString(),
+                                swarm_Compact_Level: compactLevel,
+                                swarm_Encrypt: encrypt,
+                                swarm_Pin: pin,
+                                swarm_Redundancy_Level: (Clients.Beehive.RedundancyLevel)redundancyLevel,
+                                swarm_Collection: true,
+                                swarm_Index_Document: indexDocument,
+                                swarm_Error_Document: errorDocument,
+                                cancellationToken: ct).ConfigureAwait(false)).Reference;
+                        default:
+                            throw new InvalidOperationException();
+                    }
+                },
+                maxAttempts: maxUploadAttempts,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SwarmHash> UploadFeedManifestAsync(
@@ -2935,46 +2975,64 @@ namespace Etherna.SwarmSdk
             string? errorDocument = null,
             bool? deferredUpload = null,
             RedundancyLevel redundancyLevel = RedundancyLevel.None,
+            int maxUploadAttempts = 1,
             CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(content);
+
             if (IsDryMode)
                 return encrypt == true ? SwarmReference.EncryptedZero : SwarmReference.PlainZero;
 
-            switch (ApiCompatibility)
-            {
-                case SwarmClients.Bee:
-                    return (await beeGeneratedClient.BzzPostAsync(
-                        name: name,
-                        swarm_tag: tagId?.Value,
-                        swarm_pin: pin,
-                        swarm_encrypt: encrypt,
-                        content_Type: contentType,
-                        swarm_collection: isFileCollection,
-                        swarm_index_document: indexDocument,
-                        swarm_error_document: errorDocument,
-                        swarm_postage_batch_id: batchId.ToString(),
-                        swarm_deferred_upload: deferredUpload,
-                        swarm_redundancy_level: (Clients.Bee.SwarmRedundancyLevel)redundancyLevel,
-                        body: content,
-                        cancellationToken: cancellationToken).ConfigureAwait(false)).Reference;
-                case SwarmClients.Beehive:
-                    return (await beehiveGeneratedClient.BzzPostAsync(
-                        file: new Clients.Beehive.FileParameter(
-                            data: content,
-                            fileName: name,
-                            contentType: contentType),
-                        swarm_Postage_Batch_Id: batchId.ToString(),
-                        swarm_Compact_Level: compactLevel,
-                        swarm_Encrypt: encrypt,
-                        swarm_Pin: pin,
-                        swarm_Redundancy_Level: (Clients.Beehive.RedundancyLevel)redundancyLevel,
-                        swarm_Collection: isFileCollection,
-                        swarm_Index_Document: indexDocument,
-                        swarm_Error_Document: errorDocument,
-                        cancellationToken: cancellationToken).ConfigureAwait(false)).Reference;
-                default:
-                    throw new InvalidOperationException();
-            }
+            // Retrying needs to resend the same data, so a non-seekable stream cannot be rewound.
+            if (maxUploadAttempts > 1 && !content.CanSeek)
+                throw new ArgumentException(
+                    "A seekable stream is required to retry the upload; set maxUploadAttempts to 1 for non-seekable streams.",
+                    nameof(content));
+            var startPosition = content.CanSeek ? content.Position : 0L;
+
+            return await UploadRetrier.ExecuteWithRetryAsync(
+                async ct =>
+                {
+                    if (content.CanSeek)
+                        content.Position = startPosition;
+                    switch (ApiCompatibility)
+                    {
+                        case SwarmClients.Bee:
+                            return (await beeGeneratedClient.BzzPostAsync(
+                                name: name,
+                                swarm_tag: tagId?.Value,
+                                swarm_pin: pin,
+                                swarm_encrypt: encrypt,
+                                content_Type: contentType,
+                                swarm_collection: isFileCollection,
+                                swarm_index_document: indexDocument,
+                                swarm_error_document: errorDocument,
+                                swarm_postage_batch_id: batchId.ToString(),
+                                swarm_deferred_upload: deferredUpload,
+                                swarm_redundancy_level: (Clients.Bee.SwarmRedundancyLevel)redundancyLevel,
+                                body: content,
+                                cancellationToken: ct).ConfigureAwait(false)).Reference;
+                        case SwarmClients.Beehive:
+                            return (await beehiveGeneratedClient.BzzPostAsync(
+                                file: new Clients.Beehive.FileParameter(
+                                    data: content,
+                                    fileName: name,
+                                    contentType: contentType),
+                                swarm_Postage_Batch_Id: batchId.ToString(),
+                                swarm_Compact_Level: compactLevel,
+                                swarm_Encrypt: encrypt,
+                                swarm_Pin: pin,
+                                swarm_Redundancy_Level: (Clients.Beehive.RedundancyLevel)redundancyLevel,
+                                swarm_Collection: isFileCollection,
+                                swarm_Index_Document: indexDocument,
+                                swarm_Error_Document: errorDocument,
+                                cancellationToken: ct).ConfigureAwait(false)).Reference;
+                        default:
+                            throw new InvalidOperationException();
+                    }
+                },
+                maxAttempts: maxUploadAttempts,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<SwarmHash> UploadSocAsync(

--- a/src/SwarmSdk/Services/UploadRetrier.cs
+++ b/src/SwarmSdk/Services/UploadRetrier.cs
@@ -1,0 +1,181 @@
+// Copyright 2021-present Etherna SA
+// This file is part of SwarmSDK.
+//
+// SwarmSDK is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// SwarmSDK is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with SwarmSDK.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SwarmSdk.Exceptions;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Etherna.SwarmSdk.Services
+{
+    /// <summary>
+    /// Retries an upload action on transient failures, using exponential backoff.
+    /// </summary>
+    /// <remarks>
+    /// Retrying an upload that reuses the same postage batch is safe: chunks are content-addressed and
+    /// the postage stamp for a given chunk address always maps to the same bucket, so re-sending an
+    /// already-computed chunk set neither consumes additional batch utilization nor creates new content.
+    /// This holds for the network push of a materialized chunk set; it does NOT hold when each attempt
+    /// re-encrypts the content with a fresh random key, because that produces different chunk addresses.
+    /// </remarks>
+    public static class UploadRetrier
+    {
+        // Consts.
+        /// <summary>Default base delay before the first retry; grows exponentially per attempt up to <see cref="DefaultMaxDelay"/>.</summary>
+        public static readonly TimeSpan DefaultBaseDelay = TimeSpan.FromSeconds(2);
+
+        /// <summary>Default maximum number of attempts (the initial try plus retries).</summary>
+        public const int DefaultMaxAttempts = 5;
+
+        /// <summary>Default upper bound for the delay between retries (cap of the exponential backoff).</summary>
+        public static readonly TimeSpan DefaultMaxDelay = TimeSpan.FromSeconds(30);
+
+        // Static methods.
+        /// <summary>
+        /// Runs an upload action, retrying it on transient failures with exponential backoff.
+        /// </summary>
+        /// <typeparam name="T">Type of the upload result.</typeparam>
+        /// <param name="uploadAction">
+        /// The upload to run. It must be repeatable: any stream it reads has to be rewindable or rebuilt on each
+        /// invocation, otherwise a retry would resend an already-consumed payload.
+        /// </param>
+        /// <param name="maxAttempts">Maximum number of attempts (initial try plus retries). 1 disables retrying. Defaults to <see cref="DefaultMaxAttempts"/>.</param>
+        /// <param name="baseDelay">Delay before the first retry, doubled on each subsequent retry. Defaults to <see cref="DefaultBaseDelay"/>.</param>
+        /// <param name="maxDelay">Upper bound for the backoff delay. Defaults to <see cref="DefaultMaxDelay"/>.</param>
+        /// <param name="isTransient">Predicate deciding whether a failure is transient and worth retrying. Defaults to <see cref="IsTransientError"/>.</param>
+        /// <param name="timeProvider">Time source driving the backoff delays. Defaults to <see cref="TimeProvider.System"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the first successful attempt.</returns>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+            Justification = "The transient-failure predicate decides which exception types are retried; non-transient ones are rethrown by the filter.")]
+        public static async Task<T> ExecuteWithRetryAsync<T>(
+            Func<CancellationToken, Task<T>> uploadAction,
+            int maxAttempts = DefaultMaxAttempts,
+            TimeSpan? baseDelay = null,
+            TimeSpan? maxDelay = null,
+            Func<Exception, bool>? isTransient = null,
+            TimeProvider? timeProvider = null,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(uploadAction);
+
+            var effectiveBaseDelay = baseDelay ?? DefaultBaseDelay;
+            var effectiveMaxDelay = maxDelay ?? DefaultMaxDelay;
+            var effectiveIsTransient = isTransient ?? IsTransientError;
+            var effectiveTimeProvider = timeProvider ?? TimeProvider.System;
+            if (maxAttempts < 1)
+                throw new ArgumentOutOfRangeException(nameof(maxAttempts), maxAttempts, "Max attempts must be at least 1");
+            if (effectiveBaseDelay <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(baseDelay), effectiveBaseDelay, "Base delay must be positive");
+            if (effectiveMaxDelay < effectiveBaseDelay)
+                throw new ArgumentOutOfRangeException(nameof(maxDelay), effectiveMaxDelay, "Max delay cannot be less than base delay");
+
+            for (var attempt = 1; ; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    return await uploadAction(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception e) when (
+                    attempt < maxAttempts &&
+                    !(e is OperationCanceledException && cancellationToken.IsCancellationRequested) &&
+                    effectiveIsTransient(e))
+                {
+                    // Transient failure with attempts left: back off, then retry.
+                    var delay = ComputeBackoffDelay(attempt, effectiveBaseDelay, effectiveMaxDelay);
+                    await Task.Delay(delay, effectiveTimeProvider, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Runs an upload action with no result, retrying it on transient failures with exponential backoff.
+        /// </summary>
+        /// <param name="uploadAction">
+        /// The upload to run. It must be repeatable: any stream it reads has to be rewindable or rebuilt on each
+        /// invocation, otherwise a retry would resend an already-consumed payload.
+        /// </param>
+        /// <param name="maxAttempts">Maximum number of attempts (initial try plus retries). 1 disables retrying. Defaults to <see cref="DefaultMaxAttempts"/>.</param>
+        /// <param name="baseDelay">Delay before the first retry, doubled on each subsequent retry. Defaults to <see cref="DefaultBaseDelay"/>.</param>
+        /// <param name="maxDelay">Upper bound for the backoff delay. Defaults to <see cref="DefaultMaxDelay"/>.</param>
+        /// <param name="isTransient">Predicate deciding whether a failure is transient and worth retrying. Defaults to <see cref="IsTransientError"/>.</param>
+        /// <param name="timeProvider">Time source driving the backoff delays. Defaults to <see cref="TimeProvider.System"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public static Task ExecuteWithRetryAsync(
+            Func<CancellationToken, Task> uploadAction,
+            int maxAttempts = DefaultMaxAttempts,
+            TimeSpan? baseDelay = null,
+            TimeSpan? maxDelay = null,
+            Func<Exception, bool>? isTransient = null,
+            TimeProvider? timeProvider = null,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(uploadAction);
+
+            return ExecuteWithRetryAsync(
+                async ct =>
+                {
+                    await uploadAction(ct).ConfigureAwait(false);
+                    return true;
+                },
+                maxAttempts,
+                baseDelay,
+                maxDelay,
+                isTransient,
+                timeProvider,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Determines whether an exception is a transient upload failure worth retrying.
+        /// Covers server-side errors (HTTP 408/429/500/502/503/504) and network-level faults.
+        /// </summary>
+        /// <param name="exception">The exception to classify.</param>
+        /// <returns>True if the failure looks transient; otherwise false.</returns>
+        public static bool IsTransientError(Exception exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            return exception switch
+            {
+                SwarmSdkApiException apiException =>
+                    apiException.StatusCode is 408 or 429 or 500 or 502 or 503 or 504,
+                HttpRequestException => true,
+                WebSocketException => true,
+                SocketException => true,
+                IOException => true,
+                TimeoutException => true,
+                _ => false
+            };
+        }
+
+        // Helpers.
+        private static TimeSpan ComputeBackoffDelay(int attempt, TimeSpan baseDelay, TimeSpan maxDelay)
+        {
+            // Exponential backoff: baseDelay * 2^(attempt-1), capped at maxDelay.
+            // The multiplier is computed in double to avoid Int64 overflow before the cap is applied.
+            var scaledTicks = baseDelay.Ticks * Math.Pow(2, attempt - 1);
+            return scaledTicks >= maxDelay.Ticks
+                ? maxDelay
+                : TimeSpan.FromTicks((long)scaledTicks);
+        }
+    }
+}

--- a/test/SwarmSdk.UnitTest/Services/UploadRetrierTest.cs
+++ b/test/SwarmSdk.UnitTest/Services/UploadRetrierTest.cs
@@ -1,0 +1,219 @@
+// Copyright 2021-present Etherna SA
+// This file is part of SwarmSDK.
+//
+// SwarmSDK is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// SwarmSDK is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with SwarmSDK.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.SwarmSdk.Exceptions;
+using Microsoft.Extensions.Time.Testing;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Etherna.SwarmSdk.Services
+{
+    public class UploadRetrierTest
+    {
+        // Consts.
+        private static readonly TimeSpan BaseDelay = TimeSpan.FromSeconds(1);
+
+        // Tests.
+        [Theory]
+        [InlineData(408, true)]
+        [InlineData(429, true)]
+        [InlineData(500, true)]
+        [InlineData(502, true)]
+        [InlineData(503, true)]
+        [InlineData(504, true)]
+        [InlineData(400, false)]
+        [InlineData(402, false)]
+        [InlineData(404, false)]
+        [InlineData(413, false)]
+        public void ClassifiesApiStatusCodesAsTransientOrNot(int statusCode, bool expectedTransient)
+        {
+            Assert.Equal(expectedTransient, UploadRetrier.IsTransientError(ApiException(statusCode)));
+        }
+
+        [Fact]
+        public void ClassifiesNetworkFaultsAsTransientAndOthersNot()
+        {
+            Assert.True(UploadRetrier.IsTransientError(new HttpRequestException()));
+            Assert.True(UploadRetrier.IsTransientError(new IOException()));
+            Assert.True(UploadRetrier.IsTransientError(new TimeoutException()));
+            Assert.False(UploadRetrier.IsTransientError(new InvalidOperationException()));
+        }
+
+        [Fact]
+        public async Task DoesNotRetryNonTransientError()
+        {
+            // Setup.
+            var callCount = 0;
+            Task<int> Action(CancellationToken _)
+            {
+                callCount++;
+                throw ApiException(400);
+            }
+
+            // Run & Assert.
+            await Assert.ThrowsAsync<SwarmSdkApiException>(() =>
+                UploadRetrier.ExecuteWithRetryAsync(Action, baseDelay: BaseDelay, timeProvider: new FakeTimeProvider()));
+            Assert.Equal(1, callCount); // non-transient failures abort immediately
+        }
+
+        [Fact]
+        public async Task DoesNotRunActionWhenCancellationAlreadyRequested()
+        {
+            // Setup.
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+            var callCount = 0;
+            Task<int> Action(CancellationToken _)
+            {
+                callCount++;
+                return Task.FromResult(1);
+            }
+
+            // Run & Assert.
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                UploadRetrier.ExecuteWithRetryAsync(
+                    Action, timeProvider: new FakeTimeProvider(), cancellationToken: cts.Token));
+            Assert.Equal(0, callCount);
+        }
+
+        [Fact]
+        public async Task RetriesTransientFailuresThenSucceeds()
+        {
+            // Setup.
+            // The first two attempts fail with transient errors, the third succeeds: a virtual clock
+            // releases each backoff delay so the staged outcome is observed deterministically.
+            var fakeTimeProvider = new FakeTimeProvider();
+            var callCount = 0;
+            Task<int> Action(CancellationToken _)
+            {
+                callCount++;
+                if (callCount < 3)
+                    throw ApiException(503);
+                return Task.FromResult(7);
+            }
+
+            // Run.
+            var task = UploadRetrier.ExecuteWithRetryAsync(Action, baseDelay: BaseDelay, timeProvider: fakeTimeProvider);
+            await DriveVirtualClockUntilCompletedAsync(fakeTimeProvider, task, BaseDelay);
+            var result = await task;
+
+            // Assert.
+            Assert.Equal(7, result);
+            Assert.Equal(3, callCount);
+        }
+
+        [Fact]
+        public async Task ReturnsResultWhenActionSucceedsImmediately()
+        {
+            // Setup.
+            var callCount = 0;
+            Task<int> Action(CancellationToken _)
+            {
+                callCount++;
+                return Task.FromResult(42);
+            }
+
+            // Run.
+            var result = await UploadRetrier.ExecuteWithRetryAsync(Action, timeProvider: new FakeTimeProvider());
+
+            // Assert.
+            Assert.Equal(42, result);
+            Assert.Equal(1, callCount); // no retry needed on success
+        }
+
+        [Fact]
+        public async Task ThrowsLastErrorAfterExhaustingAttempts()
+        {
+            // Setup.
+            var fakeTimeProvider = new FakeTimeProvider();
+            var callCount = 0;
+            Task<int> Action(CancellationToken _)
+            {
+                callCount++;
+                throw ApiException(500);
+            }
+
+            // Run.
+            var task = UploadRetrier.ExecuteWithRetryAsync(
+                Action, maxAttempts: 3, baseDelay: BaseDelay, timeProvider: fakeTimeProvider);
+            await DriveVirtualClockUntilCompletedAsync(fakeTimeProvider, task, BaseDelay);
+
+            // Assert.
+            await Assert.ThrowsAsync<SwarmSdkApiException>(() => task);
+            Assert.Equal(3, callCount); // initial try plus two retries
+        }
+
+        [Fact]
+        public async Task ThrowsOnInvalidMaxAttempts()
+        {
+            // Setup.
+            Task<int> Action(CancellationToken _) => Task.FromResult(1);
+
+            // Run & Assert.
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                UploadRetrier.ExecuteWithRetryAsync(Action, maxAttempts: 0, timeProvider: new FakeTimeProvider()));
+        }
+
+        [Fact]
+        public async Task VoidOverloadRetriesTransientThenCompletes()
+        {
+            // Setup.
+            var fakeTimeProvider = new FakeTimeProvider();
+            var callCount = 0;
+            Task Action(CancellationToken _)
+            {
+                callCount++;
+                if (callCount < 2)
+                    throw new HttpRequestException("transient");
+                return Task.CompletedTask;
+            }
+
+            // Run.
+            var task = UploadRetrier.ExecuteWithRetryAsync(Action, baseDelay: BaseDelay, timeProvider: fakeTimeProvider);
+            await DriveVirtualClockUntilCompletedAsync(fakeTimeProvider, task, BaseDelay);
+            await task;
+
+            // Assert.
+            Assert.Equal(2, callCount);
+        }
+
+        // Helpers.
+        private static SwarmSdkApiException ApiException(int statusCode) =>
+            new("error", statusCode, null, new Dictionary<string, IEnumerable<string>>(), null);
+
+        /// <summary>
+        /// Repeatedly advances the virtual clock by <paramref name="step"/> until the retrying task
+        /// completes, settling the async continuations between advances. Bounded by wall-clock time
+        /// so a stuck task cannot hang the test.
+        /// </summary>
+        private static async Task DriveVirtualClockUntilCompletedAsync(
+            FakeTimeProvider timeProvider,
+            Task task,
+            TimeSpan step)
+        {
+            var realTimeout = Stopwatch.StartNew();
+            while (!task.IsCompleted && realTimeout.Elapsed < TimeSpan.FromSeconds(5))
+            {
+                timeProvider.Advance(step);
+                await Task.Delay(1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce UploadRetrier, a TimeProvider-driven helper that retries an upload action on transient failures with exponential backoff. Wire an opt-in maxUploadAttempts parameter (default 1, no behavior change) into ChunksBulkUploadAsync, UploadBytesAsync, UploadFileAsync and UploadDirectoryAsync. Stream-based uploads rewind a seekable stream between attempts and reject retrying a non-seekable one. Document that retrying reuses the same postage batch and is idempotent only for plain uploads, not for encrypted ones (re-encrypted with a fresh key per try).